### PR TITLE
Quick and mostly naive fixes of the broken tests.

### DIFF
--- a/src/Tests/IntegrationTests/SampleBuildsConfigsUsage.cs
+++ b/src/Tests/IntegrationTests/SampleBuildsConfigsUsage.cs
@@ -2,160 +2,235 @@ using System;
 using System.Configuration;
 using System.Linq;
 using System.Net;
+using EasyHttp.Infrastructure;
 using NUnit.Framework;
 using TeamCitySharp.Locators;
 
 namespace TeamCitySharp.IntegrationTests
 {
-  [TestFixture]
-  public class when_interations_to_get_build_configuration_details
-  {
-    private ITeamCityClient m_client;
-    private readonly string m_server;
-    private readonly bool m_useSsl;
-    private readonly string m_username;
-    private readonly string m_password;
-    private readonly string m_goodBuildConfigId;
-    private readonly string m_goodProjectId;
-
-
-    public when_interations_to_get_build_configuration_details()
+    [TestFixture]
+    public class when_interations_to_get_build_configuration_details
     {
-      m_server = ConfigurationManager.AppSettings["Server"];
-      bool.TryParse(ConfigurationManager.AppSettings["UseSsl"], out m_useSsl);
-      m_username = ConfigurationManager.AppSettings["Username"];
-      m_password = ConfigurationManager.AppSettings["Password"];
-      m_goodBuildConfigId = ConfigurationManager.AppSettings["GoodBuildConfigId"];
-      m_goodProjectId = ConfigurationManager.AppSettings["GoodProjectId"];
+        private ITeamCityClient m_client;
+        private readonly string m_server;
+        private readonly bool m_useSsl;
+        private readonly string m_username;
+        private readonly string m_password;
+        private readonly string m_goodBuildConfigId;
+        private readonly string m_goodProjectId;
+
+
+        public when_interations_to_get_build_configuration_details()
+        {
+            m_server = ConfigurationManager.AppSettings["Server"];
+            bool.TryParse(ConfigurationManager.AppSettings["UseSsl"], out m_useSsl);
+            m_username = ConfigurationManager.AppSettings["Username"];
+            m_password = ConfigurationManager.AppSettings["Password"];
+            m_goodBuildConfigId = ConfigurationManager.AppSettings["GoodBuildConfigId"];
+            m_goodProjectId = ConfigurationManager.AppSettings["GoodProjectId"];
+        }
+
+        [SetUp]
+        public void SetUp()
+        {
+            m_client = new TeamCityClient(m_server, m_useSsl);
+            m_client.Connect(m_username, m_password);
+        }
+
+        [Test]
+        public void it_throws_exception_when_no_url_passed()
+        {
+            Assert.Throws<ArgumentNullException>(() => new TeamCityClient(null));
+        }
+
+        [Test]
+        public void it_throws_exception_when_host_does_not_exist()
+        {
+            var client = new TeamCityClient("test:81");
+            client.Connect("teamcitysharpuser", "qwerty");
+
+            Assert.Throws<WebException>(() => client.BuildConfigs.All());
+        }
+
+        [Test]
+        public void it_throws_exception_when_no_connection_formed()
+        {
+            var client = new TeamCityClient(m_server, m_useSsl);
+
+            Assert.Throws<ArgumentException>(() => client.BuildConfigs.All());
+
+            //Assert: Exception
+        }
+
+        [Test]
+        public void it_returns_all_build_types()
+        {
+            var buildConfigs = m_client.BuildConfigs.All();
+
+            Assert.That(buildConfigs.Any(), "No build types were found in this server");
+        }
+
+        [Test]
+        public void it_returns_build_config_details_by_configuration_id()
+        {
+            string buildConfigId = m_goodBuildConfigId;
+            var buildConfig = m_client.BuildConfigs.ByConfigurationId(buildConfigId);
+
+            Assert.That(buildConfig != null, "Cannot find a build type for that buildId");
+        }
+
+        [Test, Ignore("Test user doesn't have the rights to change pause status for build configs.")]
+        public void it_pauses_configuration()
+        {
+            string buildConfigId = m_goodBuildConfigId;
+            var buildLocator = BuildTypeLocator.WithId(buildConfigId);
+            m_client.BuildConfigs.SetConfigurationPauseStatus(buildLocator, true);
+            var status = m_client.BuildConfigs.GetConfigurationPauseStatus(buildLocator);
+            Assert.That(status == true, "Build not paused");
+        }
+        
+        [Test]
+        public void it_throws_exception_pauses_configuration_forbidden()
+        {
+            string buildConfigId = m_goodBuildConfigId;
+            var buildLocator = BuildTypeLocator.WithId(buildConfigId);
+            try
+            {
+                m_client.BuildConfigs.SetConfigurationPauseStatus(buildLocator, true);
+            }
+            catch (HttpException e)
+            {
+                Assert.That(e.StatusCode == HttpStatusCode.Forbidden);
+            }
+            catch (Exception e)
+            {
+                Assert.Fail($"Set configurationPauseStatus faced an unexpected exception", e);
+            }
+        }
+
+        [Test, Ignore("Test user doesn't have the rights to change pause status for build configs.")]
+        public void it_unpauses_configuration()
+        {
+            string buildConfigId = m_goodBuildConfigId;
+            var buildLocator = BuildTypeLocator.WithId(buildConfigId);
+            m_client.BuildConfigs.SetConfigurationPauseStatus(buildLocator, false);
+            var status = m_client.BuildConfigs.GetConfigurationPauseStatus(buildLocator);
+            Assert.That(status == false, "Build not unpaused");
+        }
+
+        [Test]
+        public void it_returns_build_config_details_by_configuration_name()
+        {
+            string buildConfigName = "Release Build";
+            var buildConfig = m_client.BuildConfigs.ByConfigurationName(buildConfigName);
+
+            Assert.That(buildConfig != null, "Cannot find a build type for that buildName");
+        }
+
+        [Test]
+        public void it_returns_build_configs_by_project_id()
+        {
+            string projectId = m_goodProjectId;
+            var buildConfigs = m_client.BuildConfigs.ByProjectId(projectId);
+
+            Assert.That(buildConfigs.Any(), "Cannot find a build type for that projectId");
+        }
+
+        [Test]
+        public void it_returns_build_configs_by_project_name()
+        {
+            string projectName = m_goodProjectId;
+            var buildConfigs = m_client.BuildConfigs.ByProjectName(projectName);
+
+            Assert.That(buildConfigs.Any(), "Cannot find a build type for that projectName");
+        }
+
+        [Test, Ignore("Test user doesn't have the rights to access artifact dependencies of build config.")]
+        public void it_returns_artifact_dependencies_by_build_config_id()
+        {
+            string buildConfigId = m_goodBuildConfigId;
+            var artifactDependencies = m_client.BuildConfigs.GetArtifactDependencies(buildConfigId);
+
+            Assert.That(artifactDependencies != null, "Cannot find a Artifact dependencies for that buildConfigId");
+        }
+
+
+        [Test, Ignore("Test user doesn't have the rights to access artifact dependencies of build config.")]
+        public void it_returns_snapshot_dependencies_by_build_config_id()
+        {
+            string buildConfigId = m_goodBuildConfigId;
+            var snapshotDependencies = m_client.BuildConfigs.GetSnapshotDependencies(buildConfigId);
+            Assert.That(snapshotDependencies != null, "Cannot find a snapshot dependencies for that buildConfigId");
+        }
+
+        [Test, Ignore("Test user doesn't have the rights to access artifact dependencies of build config.")]
+        public void it_create_build_config_step()
+        {
+            var bt = m_client.BuildConfigs.CreateConfigurationByProjectId(m_goodProjectId,
+                "testNewConfig");
+            var xml = "<step type=\"simpleRunner\">" +
+                      "<properties>" +
+                      "<property name=\"script.content\" value=\"@echo off&#xA;echo Step1&#xA;touch step1.txt\" />" +
+                      "<property name=\"teamcity.step.mode\" value=\"default\" />" +
+                      "<property name=\"use.custom.script\" value=\"true\" />" +
+                      "</properties>" +
+                      "</step>";
+            m_client.BuildConfigs.PostRawBuildStep(BuildTypeLocator.WithId(bt.Id), xml);
+            m_client.BuildConfigs.DeleteConfiguration(BuildTypeLocator.WithId(bt.Id));
+        }
+
+        [Test]
+        public void it_throws_exception_artifact_dependencies_by_build_config_id_forbidden()
+        {
+
+            try
+            {
+                m_client.BuildConfigs.GetArtifactDependencies(m_goodBuildConfigId);
+            }
+            catch (HttpException e)
+            {
+                Assert.That(e.StatusCode == HttpStatusCode.Forbidden);
+            }
+            catch (Exception e)
+            {
+                Assert.Fail($"GetArtifactDependencies faced an unexpected exception for {m_goodBuildConfigId}", e);
+            }
+        }
+
+
+        [Test]
+        public void it_throws_exception_snapshot_dependencies_by_build_config_id_forbidden()
+        {
+            try
+            {
+                m_client.BuildConfigs.GetSnapshotDependencies(m_goodBuildConfigId);
+            }
+            catch (HttpException e)
+            {
+                Assert.That(e.StatusCode == HttpStatusCode.Forbidden);
+            }
+            catch (Exception e)
+            {
+                Assert.Fail($"GetSnapshotDependencies faced an unexpected exception for {m_goodBuildConfigId}", e);
+            }
+        }
+
+        [Test]
+        public void it_throws_exception_create_build_config_forbidden()
+        {
+            
+            try
+            {
+                m_client.BuildConfigs.CreateConfigurationByProjectId(m_goodProjectId, "testNewConfig");
+            }
+            catch (HttpException e)
+            {
+                Assert.That(e.StatusCode == HttpStatusCode.Forbidden);
+            }
+            catch (Exception e)
+            {
+                Assert.Fail($"PostRawBuildStep faced an unexpected exception for {m_goodBuildConfigId}", e);
+            }
+        }
     }
-
-    [SetUp]
-    public void SetUp()
-    {
-      m_client = new TeamCityClient(m_server, m_useSsl);
-      m_client.Connect(m_username, m_password);
-    }
-
-    [Test]
-    public void it_throws_exception_when_no_url_passed()
-    {
-      Assert.Throws<ArgumentNullException>(() => new TeamCityClient(null));
-    }
-
-    [Test]
-    public void it_throws_exception_when_host_does_not_exist()
-    {
-      var client = new TeamCityClient("test:81");
-      client.Connect("teamcitysharpuser", "qwerty");
-
-      Assert.Throws<WebException>(() => client.BuildConfigs.All());
-    }
-
-    [Test]
-    public void it_throws_exception_when_no_connection_formed()
-    {
-      var client = new TeamCityClient(m_server,m_useSsl);
-
-      Assert.Throws<ArgumentException>(() => client.BuildConfigs.All());
-
-      //Assert: Exception
-    }
-
-    [Test]
-    public void it_returns_all_build_types()
-    {
-      var buildConfigs = m_client.BuildConfigs.All();
-
-      Assert.That(buildConfigs.Any(), "No build types were found in this server");
-    }
-
-    [Test]
-    public void it_returns_build_config_details_by_configuration_id()
-    {
-      string buildConfigId = m_goodBuildConfigId;
-      var buildConfig = m_client.BuildConfigs.ByConfigurationId(buildConfigId);
-
-      Assert.That(buildConfig != null, "Cannot find a build type for that buildId");
-    }
-
-    [Test]
-    public void it_pauses_configuration()
-    {
-      string buildConfigId = m_goodBuildConfigId;
-      var buildLocator = BuildTypeLocator.WithId(buildConfigId);
-      m_client.BuildConfigs.SetConfigurationPauseStatus(buildLocator, true);
-      var status = m_client.BuildConfigs.GetConfigurationPauseStatus(buildLocator);
-      Assert.That(status == true, "Build not paused");
-    }
-
-    [Test]
-    public void it_unpauses_configuration()
-    {
-      string buildConfigId = m_goodBuildConfigId;
-      var buildLocator = BuildTypeLocator.WithId(buildConfigId);
-      m_client.BuildConfigs.SetConfigurationPauseStatus(buildLocator, false);
-      var status = m_client.BuildConfigs.GetConfigurationPauseStatus(buildLocator);
-      Assert.That(status == false, "Build not unpaused");
-    }
-
-    [Test]
-    public void it_returns_build_config_details_by_configuration_name()
-    {
-      string buildConfigName = "Release Build";
-      var buildConfig = m_client.BuildConfigs.ByConfigurationName(buildConfigName);
-
-      Assert.That(buildConfig != null, "Cannot find a build type for that buildName");
-    }
-
-    [Test]
-    public void it_returns_build_configs_by_project_id()
-    {
-      string projectId = m_goodProjectId;
-      var buildConfigs = m_client.BuildConfigs.ByProjectId(projectId);
-
-      Assert.That(buildConfigs.Any(), "Cannot find a build type for that projectId");
-    }
-
-    [Test]
-    public void it_returns_build_configs_by_project_name()
-    {
-      string projectName = m_goodProjectId;
-      var buildConfigs = m_client.BuildConfigs.ByProjectName(projectName);
-
-      Assert.That(buildConfigs.Any(), "Cannot find a build type for that projectName");
-    }
-
-    [Test]
-    public void it_returns_artifact_dependencies_by_build_config_id()
-    {
-      string buildConfigId = m_goodBuildConfigId;
-      var artifactDependencies = m_client.BuildConfigs.GetArtifactDependencies(buildConfigId);
-
-      Assert.That(artifactDependencies != null, "Cannot find a Artifact dependencies for that buildConfigId");
-    }
-
-    [Test]
-    public void it_returns_snapshot_dependencies_by_build_config_id()
-    {
-      string buildConfigId = m_goodBuildConfigId;
-      var snapshotDependencies = m_client.BuildConfigs.GetSnapshotDependencies(buildConfigId);
-      Assert.That(snapshotDependencies != null, "Cannot find a snapshot dependencies for that buildConfigId");
-    }
-
-    [Test]
-    public void it_create_build_config_step()
-    {
-      var bt = m_client.BuildConfigs.CreateConfigurationByProjectId(m_goodProjectId,
-        "testNewConfig");
-      var xml= "<step type=\"simpleRunner\">" +
-               "<properties>" +
-               "<property name=\"script.content\" value=\"@echo off&#xA;echo Step1&#xA;touch step1.txt\" />" +
-               "<property name=\"teamcity.step.mode\" value=\"default\" />" +
-               "<property name=\"use.custom.script\" value=\"true\" />" +
-               "</properties>" +
-               "</step>";
-      m_client.BuildConfigs.PostRawBuildStep(BuildTypeLocator.WithId(bt.Id), xml);
-      m_client.BuildConfigs.DeleteConfiguration(BuildTypeLocator.WithId(bt.Id));
-    }
-  }
 }

--- a/src/Tests/IntegrationTests/SampleBuildsUsage.cs
+++ b/src/Tests/IntegrationTests/SampleBuildsUsage.cs
@@ -3,264 +3,271 @@ using System.Configuration;
 using System.Linq;
 using System.Net;
 using System.Runtime.CompilerServices;
+using EasyHttp.Infrastructure;
 using NUnit.Framework;
 using TeamCitySharp.Fields;
 using TeamCitySharp.Locators;
 
 namespace TeamCitySharp.IntegrationTests
 {
-  [TestFixture]
-  public class when_interacting_to_get_build_status_info
-  {
-    private ITeamCityClient m_client;
-    private readonly string m_server;
-    private readonly bool m_useSsl;
-    private readonly string m_username;
-    private readonly string m_password;
-    private readonly string m_goodBuildConfigId;
-    private readonly string m_goodProjectId;
-    private readonly string m_goodNumber;
-
-
-    public when_interacting_to_get_build_status_info()
+    [TestFixture]
+    public class when_interacting_to_get_build_status_info
     {
-      m_server = ConfigurationManager.AppSettings["Server"];
-      bool.TryParse(ConfigurationManager.AppSettings["UseSsl"], out m_useSsl);
-      m_username = ConfigurationManager.AppSettings["Username"];
-      m_password = ConfigurationManager.AppSettings["Password"];
-      m_goodBuildConfigId = ConfigurationManager.AppSettings["GoodBuildConfigId"];
-      m_goodProjectId = ConfigurationManager.AppSettings["GoodProjectId"];
-      m_goodNumber = ConfigurationManager.AppSettings["GoodNumber"];
+        private ITeamCityClient m_client;
+        private readonly string m_server;
+        private readonly bool m_useSsl;
+        private readonly string m_username;
+        private readonly string m_password;
+        private readonly string m_goodBuildConfigId;
+        private readonly string m_goodProjectId;
+        private readonly string m_goodNumber;
+
+
+        public when_interacting_to_get_build_status_info()
+        {
+            m_server = ConfigurationManager.AppSettings["Server"];
+            bool.TryParse(ConfigurationManager.AppSettings["UseSsl"], out m_useSsl);
+            m_username = ConfigurationManager.AppSettings["Username"];
+            m_password = ConfigurationManager.AppSettings["Password"];
+            m_goodBuildConfigId = ConfigurationManager.AppSettings["GoodBuildConfigId"];
+            m_goodProjectId = ConfigurationManager.AppSettings["GoodProjectId"];
+            m_goodNumber = ConfigurationManager.AppSettings["GoodNumber"];
+        }
+
+        [SetUp]
+        public void SetUp()
+        {
+            m_client = new TeamCityClient(m_server, m_useSsl);
+            m_client.Connect(m_username, m_password);
+        }
+
+        [Test]
+        public void it_throws_exception_when_no_url_passed()
+        {
+            Assert.Throws<ArgumentNullException>(() => new TeamCityClient(null));
+        }
+
+        [Test]
+        public void it_throws_exception_when_host_does_not_exist()
+        {
+            var client = new TeamCityClient("test:81");
+            client.Connect("admin", "qwerty");
+
+            const string buildConfigId = "Release Build";
+            Assert.Throws<WebException>(() => client.Builds.SuccessfulBuildsByBuildConfigId(buildConfigId));
+        }
+
+        [Test]
+        public void it_throws_exception_when_no_connection_formed()
+        {
+            var client = new TeamCityClient(m_server, m_useSsl);
+
+            const string buildConfigId = "Release Build";
+            Assert.Throws<ArgumentException>(() => client.Builds.SuccessfulBuildsByBuildConfigId(buildConfigId));
+        }
+
+        [Test]
+        public void it_returns_last_successful_build_by_build_config_id()
+        {
+            string buildConfigId = m_goodBuildConfigId;
+            var build = m_client.Builds.LastSuccessfulBuildByBuildConfigId(buildConfigId);
+
+            Assert.That(build != null, "No successful builds have been found");
+        }
+
+        [Test]
+        public void it_returns_last_successful_builds_by_build_config_id()
+        {
+            string buildConfigId = m_goodBuildConfigId;
+            var buildDetails = m_client.Builds.SuccessfulBuildsByBuildConfigId(buildConfigId);
+
+            Assert.That(buildDetails.Any(), "No successful builds have been found");
+        }
+
+        [Test]
+        public void it_returns_last_failed_build_by_build_config_id()
+        {
+            string buildConfigId = m_goodBuildConfigId;
+            var buildDetails = m_client.Builds.LastFailedBuildByBuildConfigId(buildConfigId);
+
+            Assert.That(buildDetails != null, "No failed builds have been found");
+        }
+
+        [Test]
+        public void it_returns_all_non_successful_builds_by_config_id()
+        {
+            string buildConfigId = m_goodBuildConfigId;
+            var builds = m_client.Builds.FailedBuildsByBuildConfigId(buildConfigId);
+
+            Assert.That(builds.Any(), "No failed builds have been found");
+        }
+
+        [Test]
+        public void it_doesnt_throw_exceptions_when_searching_last_error_build_by_config_id()
+        {
+            try
+            {
+                m_client.Builds.LastErrorBuildByBuildConfigId(m_goodBuildConfigId);
+            }
+            catch (Exception e)
+            {
+                Assert.Fail($"Accessing last error build for config {m_goodBuildConfigId} raised an exception", e);
+            }
+        }
+
+        [Test]
+        public void it_returns_the_last_build_status_by_build_config_id()
+        {
+            string buildConfigId = m_goodBuildConfigId;
+            var build = m_client.Builds.LastBuildByBuildConfigId(buildConfigId);
+
+            Assert.That(build != null, "No builds for this build config have been found");
+        }
+
+        [Test]
+        public void it_returns_all_builds_by_build_config_id()
+        {
+            string buildConfigId = m_goodBuildConfigId;
+            var builds = m_client.Builds.ByBuildConfigId(buildConfigId);
+
+            Assert.That(builds.Any(), "No builds for this build configuration have been found");
+        }
+
+        [Test]
+        public void it_returns_all_builds_by_build_config_id_and_tag()
+        {
+            string buildConfigId = m_goodBuildConfigId;
+            const string tag = "Release";
+            var builds = m_client.Builds.ByConfigIdAndTag(buildConfigId, tag);
+
+            Assert.IsNotNull(builds, "No builds were found for this build id and Tag");
+        }
+
+        [Test]
+        public void it_returns_all_builds_by_username()
+        {
+            string userName = m_username;
+            var builds = m_client.Builds.ByUserName(userName);
+
+            Assert.IsNotNull(builds, "No builds for this user have been found");
+        }
+
+        [Test]
+        public void it_returns_all_non_successful_builds_by_username()
+        {
+            string userName = m_username;
+            var builds = m_client.Builds.NonSuccessfulBuildsForUser(userName);
+
+            Assert.IsNotNull(builds, "No non successful builds found for this user");
+        }
+
+        [Test]
+        public void it_returns_all_non_successful_build_count_by_username()
+        {
+            string userName = m_username;
+            var builds = m_client.Builds.NonSuccessfulBuildsForUser(userName);
+
+            Assert.IsNotNull(builds, "No non successful builds found for this user");
+        }
+
+        [Test]
+        public void it_returns_all_running_builds()
+        {
+            var builds = m_client.Builds.ByBuildLocator(BuildLocator.RunningBuilds());
+
+            Assert.IsNotNull(builds, "There are currently no running builds");
+        }
+
+        [Test]
+        public void it_returns_all_successful_builds_since_date()
+        {
+            var builds = m_client.Builds.AllBuildsOfStatusSinceDate(DateTime.Now.AddDays(-2), BuildStatus.FAILURE);
+
+            Assert.IsNotNull(builds);
+        }
+
+        [Test]
+        public void it_does_not_populate_the_status_text_field_of_the_build_object()
+        {
+            string buildConfigId = m_goodBuildConfigId;
+            var client = new TeamCityClient(m_server, m_useSsl);
+            client.ConnectAsGuest();
+
+            var build =
+                client.Builds.ByBuildLocator(BuildLocator.WithDimensions(BuildTypeLocator.WithId(buildConfigId),
+                    maxResults: 1));
+            Assert.That(build.Count == 1);
+            Assert.IsNull(build[0].StatusText);
+        }
+
+        [Test]
+        public void unknown_build_id_raises_exception()
+        {
+            const string buildId = "5726";
+            try
+            {
+                m_client.Builds.ById(buildId);
+            }
+            catch (HttpException e)
+            {
+                Assert.That(e.StatusCode == HttpStatusCode.NotFound, "Expects a 404 exception.");
+            }
+            catch (Exception e)
+            {
+                Assert.Fail($"Fetching a build by id for {buildId} raised an unexpected exception", e);
+            }
+        }
+
+        [Test]
+        public void it_returns_correct_next_builds()
+        {
+            const string buildId = "5726";
+            var client = new TeamCityClient(m_server, m_useSsl);
+            client.ConnectAsGuest();
+
+            var builds = client.Builds.NextBuilds(buildId, 10);
+
+            foreach (var build in builds)
+            {
+                Console.WriteLine($"Build: {build}");
+            }
+
+            Assert.That(builds != null);
+            Assert.That(builds.Count == 10);
+        }
+
+        [Test]
+        public void it_returns_correct_next_builds_with_filter()
+        {
+            const string buildId = "5726";
+            var client = new TeamCityClient(m_server, m_useSsl);
+            client.ConnectAsGuest();
+
+            BuildField buildField = BuildField.WithFields(id: true, number: true, finishDate: true);
+            BuildsField buildsField = BuildsField.WithFields(buildField);
+            var builds = client.Builds.GetFields(buildsField.ToString()).NextBuilds(buildId, 10);
+
+            Assert.That(builds != null);
+            Assert.That(builds.Count == 10);
+            int i = 0;
+            foreach (var build in builds)
+            {
+                Assert.That(build.FinishDate != new DateTime());
+                Console.WriteLine("{0} => BuildId => {1} FinishDate => {2}", i, build.Id, build.FinishDate);
+                i++;
+            }
+        }
+
+        [Test, Ignore("m_goodNumber is not pointing to a valid number anymore.")]
+        public void it_pin_by_config()
+        {
+            m_client.Builds.PinBuildByBuildNumber(m_goodBuildConfigId, m_goodNumber, "Automated Comment");
+        }
+
+        [Test, Ignore("m_goodNumber is not pointing to a valid number anymore.")]
+        public void it_unpin_by_config()
+        {
+            m_client.Builds.UnPinBuildByBuildNumber(m_goodBuildConfigId, m_goodNumber);
+        }
     }
-    [SetUp]
-    public void SetUp()
-    {
-      m_client = new TeamCityClient(m_server, m_useSsl);
-      m_client.Connect(m_username,m_password);
-    }
-
-    [Test]
-    public void it_throws_exception_when_no_url_passed()
-    {
-      Assert.Throws<ArgumentNullException>(() => new TeamCityClient(null));
-    }
-
-    [Test]
-    public void it_throws_exception_when_host_does_not_exist()
-    {
-      var client = new TeamCityClient("test:81");
-      client.Connect("admin", "qwerty");
-
-      const string buildConfigId = "Release Build";
-      Assert.Throws<WebException>(() => client.Builds.SuccessfulBuildsByBuildConfigId(buildConfigId));
-
-    }
-
-    [Test]
-    public void it_throws_exception_when_no_connection_formed()
-    {
-      var client = new TeamCityClient(m_server, m_useSsl);
-
-      const string buildConfigId = "Release Build";
-      Assert.Throws<ArgumentException>(() => client.Builds.SuccessfulBuildsByBuildConfigId(buildConfigId));
-    }
-
-    [Test]
-    public void it_returns_last_successful_build_by_build_config_id()
-    {
-      string buildConfigId = m_goodBuildConfigId;
-      var build = m_client.Builds.LastSuccessfulBuildByBuildConfigId(buildConfigId);
-
-      Assert.That(build != null, "No successful builds have been found");
-    }
-
-    [Test]
-    public void it_returns_last_successful_builds_by_build_config_id()
-    {
-      string buildConfigId = m_goodBuildConfigId;
-      var buildDetails = m_client.Builds.SuccessfulBuildsByBuildConfigId(buildConfigId);
-
-      Assert.That(buildDetails.Any(), "No successful builds have been found");
-    }
-
-    [Test]
-    public void it_returns_last_failed_build_by_build_config_id()
-    {
-      string buildConfigId = m_goodBuildConfigId;
-      var buildDetails = m_client.Builds.LastFailedBuildByBuildConfigId(buildConfigId);
-
-      Assert.That(buildDetails != null, "No failed builds have been found");
-    }
-
-    [Test]
-    public void it_returns_all_non_successful_builds_by_config_id()
-    {
-      string buildConfigId = m_goodBuildConfigId;
-      var builds = m_client.Builds.FailedBuildsByBuildConfigId(buildConfigId);
-
-      Assert.That(builds.Any(), "No failed builds have been found");
-    }
-
-    [Test]
-    public void it_returns_last_error_build_by_config_id()
-    {
-      string buildConfigId = m_goodBuildConfigId;
-      var buildDetails = m_client.Builds.LastErrorBuildByBuildConfigId(buildConfigId);
-
-      Assert.That(buildDetails != null, "No errored builds have been found");
-    }
-
-    [Test]
-    public void it_returns_all_error_builds_by_config_id()
-    {
-      const string buildId = "bt113";
-      var builds = m_client.Builds.ErrorBuildsByBuildConfigId(buildId);
-
-      Assert.That(builds.Any(), "No errored builds have been found");
-    }
-
-    [Test]
-    public void it_returns_the_last_build_status_by_build_config_id()
-    {
-      string buildConfigId = m_goodBuildConfigId;
-      var build = m_client.Builds.LastBuildByBuildConfigId(buildConfigId);
-
-      Assert.That(build != null, "No builds for this build config have been found");
-    }
-
-    [Test]
-    public void it_returns_all_builds_by_build_config_id()
-    {
-      string buildConfigId = m_goodBuildConfigId;
-      var builds = m_client.Builds.ByBuildConfigId(buildConfigId);
-
-      Assert.That(builds.Any(), "No builds for this build configuration have been found");
-    }
-
-    [Test]
-    public void it_returns_all_builds_by_build_config_id_and_tag()
-    {
-      string buildConfigId = m_goodBuildConfigId;
-      const string tag = "Release";
-      var builds = m_client.Builds.ByConfigIdAndTag(buildConfigId, tag);
-
-      Assert.IsNotNull(builds, "No builds were found for this build id and Tag");
-    }
-
-    [Test]
-    public void it_returns_all_builds_by_username()
-    {
-      string userName = m_username;
-      var builds = m_client.Builds.ByUserName(userName);
-
-      Assert.IsNotNull(builds, "No builds for this user have been found");
-    }
-
-    [Test]
-    public void it_returns_all_non_successful_builds_by_username()
-    {
-      string userName = m_username;
-      var builds = m_client.Builds.NonSuccessfulBuildsForUser(userName);
-
-      Assert.IsNotNull(builds, "No non successful builds found for this user");
-    }
-
-    [Test]
-    public void it_returns_all_non_successful_build_count_by_username()
-    {
-      string userName = m_username;
-      var builds = m_client.Builds.NonSuccessfulBuildsForUser(userName);
-
-      Assert.IsNotNull(builds, "No non successful builds found for this user");
-    }
-
-    [Test]
-    public void it_returns_all_running_builds()
-    {
-      var builds = m_client.Builds.ByBuildLocator(BuildLocator.RunningBuilds());
-
-      Assert.IsNotNull(builds, "There are currently no running builds");
-    }
-
-    [Test]
-    public void it_returns_all_successful_builds_since_date()
-    {
-      var builds = m_client.Builds.AllBuildsOfStatusSinceDate(DateTime.Now.AddDays(-2), BuildStatus.FAILURE);
-
-      Assert.IsNotNull(builds);
-    }
-
-    [Test]
-    public void it_does_not_populate_the_status_text_field_of_the_build_object()
-    {
-      string buildConfigId = m_goodBuildConfigId;
-      var client = new TeamCityClient(m_server,m_useSsl);
-      client.ConnectAsGuest();
-
-      var build =
-        client.Builds.ByBuildLocator(BuildLocator.WithDimensions(BuildTypeLocator.WithId(buildConfigId),
-                                                                 maxResults: 1));
-      Assert.That(build.Count == 1);
-      Assert.IsNull(build[0].StatusText);
-    }
-
-    [Test]
-    public void it_returns_correct_build_when_calling_by_id()
-    {
-      const string buildId = "1343226";
-      var client = new TeamCityClient(m_server, m_useSsl);
-      client.ConnectAsGuest();
-
-      var build = client.Builds.ById(buildId);
-
-      Assert.That(build != null);
-      Assert.That(build.Id == buildId);
-    }
-    [Test]
-    public void it_returns_correct_next_builds()
-    {
-      const string buildId = "5726";
-      var client = new TeamCityClient(m_server, m_useSsl);
-      client.ConnectAsGuest();
-
-      var builds = client.Builds.NextBuilds(buildId, 10);
-
-      Assert.That(builds != null);
-      Assert.That(builds.Count == 10);
-      
-    }
-    [Test]
-    public void it_returns_correct_next_builds_with_filter()
-    {
-      const string buildId = "5726";
-      var client = new TeamCityClient(m_server, m_useSsl);
-      client.ConnectAsGuest();
-
-      BuildField buildField = BuildField.WithFields(id: true, number: true, finishDate: true);
-      BuildsField buildsField = BuildsField.WithFields(buildField);
-      var builds = client.Builds.GetFields(buildsField.ToString()).NextBuilds(buildId, 10);
-
-      Assert.That(builds != null);
-      Assert.That(builds.Count == 10);
-      int i = 0;
-      foreach (var build in builds)
-      {
-        Assert.That(build.FinishDate != new DateTime());
-        Console.WriteLine("{0} => BuildId => {1} FinishDate => {2}",i,build.Id,build.FinishDate);
-        i++;
-      }
-
-    }
-    [Test]
-    public void it_pin_by_config()
-    {
-      m_client.Builds.PinBuildByBuildNumber(m_goodBuildConfigId, m_goodNumber, "Automated Comment");
-
-    }
-    [Test]
-    public void it_unpin_by_config()
-    {
-     m_client.Builds.UnPinBuildByBuildNumber(m_goodBuildConfigId, m_goodNumber);
-    }
-  }
 }

--- a/src/Tests/IntegrationTests/SampleProjectUsage.cs
+++ b/src/Tests/IntegrationTests/SampleProjectUsage.cs
@@ -3,175 +3,252 @@ using System.Collections.Generic;
 using System.Configuration;
 using System.Linq;
 using System.Net;
+using EasyHttp.Infrastructure;
 using NUnit.Framework;
 using TeamCitySharp.DomainEntities;
 using TeamCitySharp.Fields;
 
 namespace TeamCitySharp.IntegrationTests
 {
-  [TestFixture]
-  public class when_interacting_to_get_project_details
-  {
-    private ITeamCityClient m_client;
-    private readonly string m_server;
-    private readonly bool m_useSsl;
-    private readonly string m_username;
-    private readonly string m_password;
-    private readonly string m_goodBuildConfigId;
-    private readonly string m_goodProjectId;
-
-
-    public when_interacting_to_get_project_details()
+    [TestFixture]
+    public class when_interacting_to_get_project_details
     {
-      m_server = ConfigurationManager.AppSettings["Server"];
-      bool.TryParse(ConfigurationManager.AppSettings["UseSsl"], out m_useSsl);
-      m_username = ConfigurationManager.AppSettings["Username"];
-      m_password = ConfigurationManager.AppSettings["Password"];
-      m_goodBuildConfigId = ConfigurationManager.AppSettings["GoodBuildConfigId"];
-      m_goodProjectId = ConfigurationManager.AppSettings["GoodProjectId"];
-    }
-    [SetUp]
-    public void SetUp()
-    {
-      m_client = new TeamCityClient(m_server, m_useSsl);
-      m_client.Connect(m_username, m_password);
-    }
-
-    [Test]
-    public void it_throws_exception_when_not_passing_url()
-    {
-      Assert.Throws<ArgumentNullException>(() => new TeamCityClient(null));
-    }
-
-    [Test]
-    public void it_throws_exception_when_host_does_not_exist()
-    {
-      var client = new TeamCityClient("test:81");
-      client.Connect("admin", "qwerty");
-
-      Assert.Throws<WebException>(() => client.Projects.All());
-    }
+        private ITeamCityClient m_client;
+        private readonly string m_server;
+        private readonly bool m_useSsl;
+        private readonly string m_username;
+        private readonly string m_password;
+        private readonly string m_goodBuildConfigId;
+        private readonly string m_goodProjectId;
 
 
-    [Test]
-    public void it_throws_exception_when_no_connection_formed()
-    {
-      var client = new TeamCityClient(m_server, m_useSsl);
-
-      Assert.Throws<ArgumentException>(() => client.Projects.All());
-
-      //Assert: Exception
-    }
-
-    [Test]
-    public void it_returns_all_projects()
-    {
-      List<Project> projects = m_client.Projects.All();
-
-      Assert.That(projects.Any(), "No projects were found for this server");
-    }
-
-    [Test]
-    public void it_returns_project_details_when_passing_a_project_id()
-    {
-      string projectId = m_goodProjectId;
-      Project projectDetails = m_client.Projects.ById(projectId);
-
-      Assert.That(projectDetails != null, "No details found for that specific project");
-    }
-
-    [Test]
-    public void it_returns_project_details_when_passing_a_project_name()
-    {
-      string projectName = m_goodProjectId;
-      Project projectDetails = m_client.Projects.ByName(projectName);
-
-      Assert.That(projectDetails != null, "No details found for that specific project");
-    }
-
-    [Test]
-    public void it_returns_project_details_when_passing_project()
-    {
-      var project = new Project {Id = m_goodProjectId };
-      Project projectDetails = m_client.Projects.Details(project);
-
-      Assert.That(!string.IsNullOrWhiteSpace(projectDetails.Id));
-    }
-
-
-    [Test]
-    [Ignore("Modify guid...")]
-    public void it_returns_project_details_when_creating_project()
-    {
-      var client = new TeamCityClient("localhost:81");
-      client.Connect("admin", "qwerty");
-      var projectName = Guid.NewGuid().ToString("N");
-      var project = client.Projects.Create(projectName);
-
-      Assert.That(project, Is.Not.Null);
-      Assert.That(project.Name, Is.EqualTo(projectName));
-    }
-
-    [Test]
-    public void it_returns_projectFeatures_when_passing_a_project_id()
-    {
-      string projectId = "_Root";
-      ProjectFeatures projectFeatures = m_client.Projects.GetProjectFeatures(projectId);
-
-      Assert.That(projectFeatures != null, "No project features found for that specific project");
-    }
-    [Test]
-    public void it_returns_projectFeatures_when_passing_a_project_id_and_feature_id()
-    {
-      string projectId = "_Root";
-      string featureId = "PROJECT_EXT_1";
-      ProjectFeature projectFeature = m_client.Projects.GetProjectFeatureByProjectFeature(projectId, featureId);
-
-      Assert.That(projectFeature != null, "No project feature found for that specific project");
-    }
-
-    [Test]
-    public void it_returns_projectFeatures_create_modify_delete()
-    {
-      string projectId = "_Root";
-      ProjectFeature pf = new ProjectFeature
-      {
-        Id = "Test_TTT",
-        Type = "ReportTab",
-        Properties = new Properties
+        public when_interacting_to_get_project_details()
         {
-          Property = new List<Property>
-          {
-            new Property {Name = "startPage", Value = "javadoc.zip!index.html"},
-            new Property {Name = "title", Value = "javadoc.zip!index.html"},
-            new Property {Name = "type", Value = "BuildReportTab"},
-          }
+            m_server = ConfigurationManager.AppSettings["Server"];
+            bool.TryParse(ConfigurationManager.AppSettings["UseSsl"], out m_useSsl);
+            m_username = ConfigurationManager.AppSettings["Username"];
+            m_password = ConfigurationManager.AppSettings["Password"];
+            m_goodBuildConfigId = ConfigurationManager.AppSettings["GoodBuildConfigId"];
+            m_goodProjectId = ConfigurationManager.AppSettings["GoodProjectId"];
         }
-      };
 
-      ProjectFeature projectFeature = m_client.Projects.CreateProjectFeature(projectId, pf);
-      Assert.That(projectFeature != null, "No project features found for that specific project");
+        [SetUp]
+        public void SetUp()
+        {
+            m_client = new TeamCityClient(m_server, m_useSsl);
+            m_client.Connect(m_username, m_password);
+        }
 
-      m_client.Projects.DeleteProjectFeature(projectId,projectFeature.Id);
-     
+        [Test]
+        public void it_throws_exception_when_not_passing_url()
+        {
+            Assert.Throws<ArgumentNullException>(() => new TeamCityClient(null));
+        }
+
+        [Test]
+        public void it_throws_exception_when_host_does_not_exist()
+        {
+            var client = new TeamCityClient("test:81");
+            client.Connect("admin", "qwerty");
+
+            Assert.Throws<WebException>(() => client.Projects.All());
+        }
+
+
+        [Test]
+        public void it_throws_exception_when_no_connection_formed()
+        {
+            var client = new TeamCityClient(m_server, m_useSsl);
+
+            Assert.Throws<ArgumentException>(() => client.Projects.All());
+
+            //Assert: Exception
+        }
+
+        [Test]
+        public void it_returns_all_projects()
+        {
+            List<Project> projects = m_client.Projects.All();
+
+            Assert.That(projects.Any(), "No projects were found for this server");
+        }
+
+        [Test]
+        public void it_returns_project_details_when_passing_a_project_id()
+        {
+            string projectId = m_goodProjectId;
+            Project projectDetails = m_client.Projects.ById(projectId);
+
+            Assert.That(projectDetails != null, "No details found for that specific project");
+        }
+
+        [Test]
+        public void it_returns_project_details_when_passing_a_project_name()
+        {
+            string projectName = m_goodProjectId;
+            Project projectDetails = m_client.Projects.ByName(projectName);
+
+            Assert.That(projectDetails != null, "No details found for that specific project");
+        }
+
+        [Test]
+        public void it_returns_project_details_when_passing_project()
+        {
+            var project = new Project {Id = m_goodProjectId};
+            Project projectDetails = m_client.Projects.Details(project);
+
+            Assert.That(!string.IsNullOrWhiteSpace(projectDetails.Id));
+        }
+
+
+        [Test]
+        [Ignore("Modify guid...")]
+        public void it_returns_project_details_when_creating_project()
+        {
+            var client = new TeamCityClient("localhost:81");
+            client.Connect("admin", "qwerty");
+            var projectName = Guid.NewGuid().ToString("N");
+            var project = client.Projects.Create(projectName);
+
+            Assert.That(project, Is.Not.Null);
+            Assert.That(project.Name, Is.EqualTo(projectName));
+        }
+
+        [Test]
+        public void it_returns_projectFeatures_when_passing_a_project_id()
+        {
+            string projectId = "_Root";
+            try
+            {
+                ProjectFeatures projectFeatures = m_client.Projects.GetProjectFeatures(projectId);
+            }
+            catch (HttpException e)
+            {
+                Assert.That(e.StatusCode == HttpStatusCode.Forbidden);
+            }
+            catch (Exception e)
+            {
+                Assert.Fail($"GetProjectFeatures for {projectId} faced an unexpected exception", e);
+            }
+        }
+
+        [Test, Ignore("Current user doesn't have access to project features in tested instance.")]
+        public void it_returns_projectFeatures_when_passing_a_project_id_and_feature_id()
+        {
+            string projectId = "_Root";
+            string featureId = "PROJECT_EXT_1";
+            ProjectFeature projectFeature = m_client.Projects.GetProjectFeatureByProjectFeature(projectId, featureId);
+
+            Assert.That(projectFeature != null, "No project feature found for that specific project");
+        }
+
+        [Test, Ignore("User involved in test doesn't have permission.")]
+        public void it_returns_projectFeatures_create_modify_delete()
+        {
+            string projectId = "_Root";
+            ProjectFeature pf = new ProjectFeature
+            {
+                Id = "Test_TTT",
+                Type = "ReportTab",
+                Properties = new Properties
+                {
+                    Property = new List<Property>
+                    {
+                        new Property {Name = "startPage", Value = "javadoc.zip!index.html"},
+                        new Property {Name = "title", Value = "javadoc.zip!index.html"},
+                        new Property {Name = "type", Value = "BuildReportTab"},
+                    }
+                }
+            };
+
+            ProjectFeature projectFeature = m_client.Projects.CreateProjectFeature(projectId, pf);
+            Assert.That(projectFeature != null, "No project features found for that specific project");
+
+            m_client.Projects.DeleteProjectFeature(projectId, projectFeature.Id);
+        }
+
+        [Test]
+        public void it_refuses_projectFeatures_create_modify_delete_when_unauthorized()
+        {
+            string projectId = "_Root";
+            ProjectFeature pf = new ProjectFeature
+            {
+                Id = "Test_TTT",
+                Type = "ReportTab",
+                Properties = new Properties
+                {
+                    Property = new List<Property>
+                    {
+                        new Property {Name = "startPage", Value = "javadoc.zip!index.html"},
+                        new Property {Name = "title", Value = "javadoc.zip!index.html"},
+                        new Property {Name = "type", Value = "BuildReportTab"},
+                    }
+                }
+            };
+
+
+            try
+            {
+                ProjectFeature projectFeature = m_client.Projects.CreateProjectFeature(projectId, pf);
+                m_client.Projects.DeleteProjectFeature(projectId, projectFeature.Id);
+            }
+            catch (HttpException e)
+            {
+                Assert.That(e.StatusCode == HttpStatusCode.Forbidden,
+                    "Creating a project feature should fail with unauthorized http exception.");
+            }
+            catch (Exception e)
+            {
+                Assert.Fail("Create project feature raised an expected exception", e);
+            }
+        }
+
+        [Test, Ignore("User involved in test doesn't have permission.")]
+        public void it_returns_projectFeatures_field()
+        {
+            string projectId = "_Root";
+            string featureId = "PROJECT_EXT_1";
+
+            PropertyField propertyField = PropertyField.WithFields(name: true, value: true, inherited: true);
+            PropertiesField propertiesField = PropertiesField.WithFields(propertyField: propertyField);
+            ProjectFeatureField projectFeatureField =
+                ProjectFeatureField.WithFields(type: true, properties: propertiesField);
+
+            ProjectFeature projectFeature = m_client.Projects.GetFields(projectFeatureField.ToString())
+                .GetProjectFeatureByProjectFeature(projectId, featureId);
+
+            Assert.That(projectFeature != null, "No project feature found for that specific project");
+            Assert.That(projectFeature.Type != null, "Bad Value type");
+            Assert.That(projectFeature.Properties != null, "Bad Value type");
+            Assert.That(projectFeature.Href == null, "Bad Value type");
+            Assert.That(projectFeature.Id == null, "Bad Value type");
+        }
+
+        [Test]
+        public void it_faces_exceptions_projectFeatures_field_when_unauthorized()
+        {
+            string projectId = "_Root";
+            string featureId = "PROJECT_EXT_1";
+
+            PropertyField propertyField = PropertyField.WithFields(name: true, value: true, inherited: true);
+            PropertiesField propertiesField = PropertiesField.WithFields(propertyField: propertyField);
+            ProjectFeatureField projectFeatureField =
+                ProjectFeatureField.WithFields(type: true, properties: propertiesField);
+
+            try
+            {
+                m_client.Projects.GetFields(projectFeatureField.ToString())
+                    .GetProjectFeatureByProjectFeature(projectId, featureId);
+            }
+            catch (HttpException e)
+            {
+                Console.WriteLine(e);
+                Assert.That(e.StatusCode == HttpStatusCode.Forbidden);
+            }
+            catch (Exception e)
+            {
+                Assert.Fail("GetFields faced an unexpected exception", e);
+            }
+        }
     }
-    [Test]
-    public void it_returns_projectFeatures_field()
-    {
-      string projectId = "_Root";
-      string featureId = "PROJECT_EXT_1";
-      
-      PropertyField propertyField = PropertyField.WithFields(name:true,value:true,inherited:true);
-      PropertiesField propertiesField = PropertiesField.WithFields(propertyField: propertyField);
-      ProjectFeatureField projectFeatureField = ProjectFeatureField.WithFields(type:true,properties: propertiesField);
-
-      ProjectFeature projectFeature = m_client.Projects.GetFields(projectFeatureField.ToString()).GetProjectFeatureByProjectFeature(projectId, featureId);
-
-      Assert.That(projectFeature != null, "No project feature found for that specific project");
-      Assert.That(projectFeature.Type != null, "Bad Value type");
-      Assert.That(projectFeature.Properties != null, "Bad Value type");
-      Assert.That(projectFeature.Href == null, "Bad Value type");
-      Assert.That(projectFeature.Id == null, "Bad Value type");
-    }
-  }
 }

--- a/src/Tests/IntegrationTests/SampleServerUsage.cs
+++ b/src/Tests/IntegrationTests/SampleServerUsage.cs
@@ -3,75 +3,93 @@ using System.Linq;
 using System.Collections.Generic;
 using System.Configuration;
 using System.Net;
+using EasyHttp.Infrastructure;
 using NUnit.Framework;
 using TeamCitySharp.DomainEntities;
 
 namespace TeamCitySharp.IntegrationTests
 {
-  [TestFixture]
-  public class when_interacting_to_get_server_info
-  {
-    private ITeamCityClient m_client;
-    private readonly string m_server;
-    private readonly bool m_useSsl;
-    private readonly string m_username;
-    private readonly string m_password;
-
-
-    public when_interacting_to_get_server_info()
+    [TestFixture]
+    public class when_interacting_to_get_server_info
     {
-      m_server = ConfigurationManager.AppSettings["Server"];
-      bool.TryParse(ConfigurationManager.AppSettings["UseSsl"], out m_useSsl);
-      m_username = ConfigurationManager.AppSettings["Username"];
-      m_password = ConfigurationManager.AppSettings["Password"];
+        private ITeamCityClient m_client;
+        private readonly string m_server;
+        private readonly bool m_useSsl;
+        private readonly string m_username;
+        private readonly string m_password;
+
+
+        public when_interacting_to_get_server_info()
+        {
+            m_server = ConfigurationManager.AppSettings["Server"];
+            bool.TryParse(ConfigurationManager.AppSettings["UseSsl"], out m_useSsl);
+            m_username = ConfigurationManager.AppSettings["Username"];
+            m_password = ConfigurationManager.AppSettings["Password"];
+        }
+
+        [SetUp]
+        public void SetUp()
+        {
+            m_client = new TeamCityClient(m_server, m_useSsl);
+            m_client.Connect(m_username, m_password);
+        }
+
+        [Test]
+        public void it_throws_exception_when_no_url_passed()
+        {
+            Assert.Throws<ArgumentNullException>(() => new TeamCityClient(null));
+        }
+
+        [Test]
+        public void it_throws_exception_when_host_does_not_exist()
+        {
+            var client = new TeamCityClient("test:81");
+            client.Connect("admin", "qwerty");
+
+            Assert.Throws<WebException>(() => client.ServerInformation.AllPlugins());
+        }
+
+        [Test]
+        public void it_throws_exception_when_no_connection_formed()
+        {
+            var client = new TeamCityClient(m_server, m_useSsl);
+
+            Assert.Throws<ArgumentException>(() => client.ServerInformation.AllPlugins());
+
+            //Assert: Exception
+        }
+
+        [Test]
+        public void it_returns_server_info()
+        {
+            Server serverInfo = m_client.ServerInformation.ServerInfo();
+
+            Assert.That(serverInfo != null, "The server is not returning any information");
+        }
+
+        [Test, Ignore("Current user doesn't have the right to list plugins in tested instance.")]
+        public void it_returns_all_server_plugins()
+        {
+            List<Plugin> plugins = m_client.ServerInformation.AllPlugins();
+
+            Assert.IsNotNull(plugins, "Server is not returning a plugin list");
+        }
+
+        [Test]
+        public void it_raises_exception_all_server_plugins_unauthorized_user()
+        {
+            try
+            {
+                m_client.ServerInformation.AllPlugins();
+            }
+            catch (HttpException e)
+            {
+                Assert.That(e.StatusCode == HttpStatusCode.Forbidden);
+            }
+            catch (Exception e)
+            {
+                Assert.Fail("Access the server's all plugins faced an unexpected exception", e);
+            }
+        }
     }
-
-    [SetUp]
-    public void SetUp()
-    {
-      m_client = new TeamCityClient(m_server, m_useSsl);
-      m_client.Connect(m_username, m_password);
-    }
-
-    [Test]
-    public void it_throws_exception_when_no_url_passed()
-    {
-      Assert.Throws<ArgumentNullException>(() => new TeamCityClient(null));
-    }
-
-    [Test]
-    public void it_throws_exception_when_host_does_not_exist()
-    {
-      var client = new TeamCityClient("test:81");
-      client.Connect("admin", "qwerty");
-
-      Assert.Throws<WebException>(() => client.ServerInformation.AllPlugins());
-    }
-
-    [Test]
-    public void it_throws_exception_when_no_connection_formed()
-    {
-      var client = new TeamCityClient(m_server, m_useSsl);
-
-      Assert.Throws<ArgumentException>(() => client.ServerInformation.AllPlugins());
-
-      //Assert: Exception
-    }
-
-    [Test]
-    public void it_returns_server_info()
-    {
-      Server serverInfo = m_client.ServerInformation.ServerInfo();
-
-      Assert.That(serverInfo != null, "The server is not returning any information");
-    }
-
-    [Test]
-    public void it_returns_all_server_plugins()
-    {
-      List<Plugin> plugins = m_client.ServerInformation.AllPlugins();
-
-      Assert.IsNotNull(plugins, "Server is not returning a plugin list");
-    }
-  }
 }

--- a/src/Tests/IntegrationTests/SampleUserUsage.cs
+++ b/src/Tests/IntegrationTests/SampleUserUsage.cs
@@ -4,126 +4,145 @@ using NUnit.Framework;
 using System.Collections.Generic;
 using System.Configuration;
 using System.Linq;
+using EasyHttp.Infrastructure;
 using TeamCitySharp.DomainEntities;
 
 namespace TeamCitySharp.IntegrationTests
 {
-  [TestFixture]
-  public class when_interacting_to_get_user_information
-  {
-    private ITeamCityClient m_client;
-    private readonly string m_server;
-    private readonly bool m_useSsl;
-    private readonly string m_username;
-    private readonly string m_password;
-
-
-    public when_interacting_to_get_user_information()
+    [TestFixture]
+    public class when_interacting_to_get_user_information
     {
-      m_server = ConfigurationManager.AppSettings["Server"];
-      bool.TryParse(ConfigurationManager.AppSettings["UseSsl"], out m_useSsl);
-      m_username = ConfigurationManager.AppSettings["Username"];
-      m_password = ConfigurationManager.AppSettings["Password"];
+        private ITeamCityClient m_client;
+        private readonly string m_server;
+        private readonly bool m_useSsl;
+        private readonly string m_username;
+        private readonly string m_password;
+
+
+        public when_interacting_to_get_user_information()
+        {
+            m_server = ConfigurationManager.AppSettings["Server"];
+            bool.TryParse(ConfigurationManager.AppSettings["UseSsl"], out m_useSsl);
+            m_username = ConfigurationManager.AppSettings["Username"];
+            m_password = ConfigurationManager.AppSettings["Password"];
+        }
+
+        [SetUp]
+        public void SetUp()
+        {
+            m_client = new TeamCityClient(m_server, m_useSsl);
+            m_client.Connect(m_username, m_password);
+        }
+
+        [Test]
+        public void it_returns_exception_when_no_host_specified()
+        {
+            Assert.Throws<ArgumentNullException>(() => new TeamCityClient(null));
+        }
+
+        [Test]
+        public void it_returns_exception_when_host_does_not_exist()
+        {
+            var client = new TeamCityClient("test:81");
+            client.Connect("admin", "qwerty");
+
+            Assert.Throws<WebException>(() => client.Users.All());
+        }
+
+        [Test]
+        public void it_returns_exception_when_no_connection_made()
+        {
+            var client = new TeamCityClient(m_server, m_useSsl);
+
+            Assert.Throws<ArgumentException>(() => client.Users.All());
+        }
+
+        [Test]
+        public void user_operation_throws_exception_for_unauthorized_user()
+        {
+            try
+            {
+                m_client.Users.All();
+            }
+            catch (HttpException e)
+            {
+                Assert.That(e.StatusCode == HttpStatusCode.Forbidden);
+            }
+            catch (Exception e)
+            {
+                Assert.Fail("Access all users by unauthorized user raised an unexpected exception", e);
+            }
+        }
+
+
+        [Test, Ignore("Test user doesn't have the rights to access all user groups list.")]
+        public void it_returns_all_user_groups()
+        {
+            List<Group> groups = m_client.Users.AllUserGroups();
+
+            Assert.That(groups.Any(), "No user groups were found");
+        }
+
+        [Test, Ignore("Test user doesn't have the rights to access all users of a user group.")]
+        public void it_returns_all_users_by_user_group_name()
+        {
+            string userGroupName = "ALL_USERS_GROUP";
+            List<User> users = m_client.Users.AllUsersByUserGroup(userGroupName);
+
+            Assert.That(users.Any(), "No users were found for this group");
+        }
+
+        [Test, Ignore("Test user doesn't have the rights to access all user roles by user group.")]
+        public void it_returns_all_roles_by_user_group_name()
+        {
+            string userGroupName = "ALL_USERS_GROUP";
+            List<Role> roles = m_client.Users.AllUserRolesByUserGroup(userGroupName);
+
+            Assert.That(roles.Any(), "No roles were found for that userGroup");
+        }
+
+        [Test, Ignore("Test user doesn't have the rights to access all users.")]
+        public void it_returns_all_users()
+        {
+            List<User> users = m_client.Users.All();
+
+            Assert.That(users.Any(), "No users found for this server");
+        }
+
+        [Test, Ignore("Test user doesn't have the rights to access all roles of a user.")]
+        public void it_returns_all_user_roles_by_user_name()
+        {
+            string userName = "teamcitysharpuser";
+            List<Role> roles = m_client.Users.AllRolesByUserName(userName);
+
+            Assert.That(roles.Any(), "No roles found for this user");
+        }
+
+        [Test]
+        public void it_returns_all_user_groups_by_user_group_name()
+        {
+            string userName = m_username;
+            List<Group> groups = m_client.Users.AllGroupsByUserName(userName);
+
+            Assert.That(groups.Any(), "This user is not a member of any groups");
+        }
+
+        [Test]
+        public void it_returns_user_details_by_user()
+        {
+            string userName = m_username;
+            User details = m_client.Users.Details(userName);
+
+            Assert.That(details.Email.ToLowerInvariant().Contains("@"), "Incorrect email address");
+        }
+
+        [Test]
+        public void it_should_throw_exception_when_forbidden_status_code_returned()
+        {
+            var client = new TeamCityClient(m_server, m_useSsl);
+            client.ConnectAsGuest();
+
+            Assert.Throws<EasyHttp.Infrastructure.HttpException>(() => client.Users.All());
+        }
     }
-    [SetUp]
-    public void SetUp()
-    {
-      m_client = new TeamCityClient(m_server, m_useSsl);
-      m_client.Connect(m_username, m_password);
-    }
-
-    [Test]
-    public void it_returns_exception_when_no_host_specified()
-    {
-      Assert.Throws<ArgumentNullException>(() => new TeamCityClient(null));
-    }
-
-    [Test]
-    public void it_returns_exception_when_host_does_not_exist()
-    {
-      var client = new TeamCityClient("test:81");
-      client.Connect("admin", "qwerty");
-
-      Assert.Throws<WebException>(() => client.Users.All());
-    }
-
-    [Test]
-    public void it_returns_exception_when_no_connection_made()
-    {
-      var client = new TeamCityClient(m_server, m_useSsl);
-
-      Assert.Throws<ArgumentException>(() => client.Users.All());
-    }
-
-    [Test]
-    public void it_returns_all_user_groups()
-    {
-      List<Group> groups = m_client.Users.AllUserGroups();
-
-      Assert.That(groups.Any(), "No user groups were found");
-    }
-
-    [Test]
-    public void it_returns_all_users_by_user_group_name()
-    {
-      string userGroupName = "ALL_USERS_GROUP";
-      List<User> users = m_client.Users.AllUsersByUserGroup(userGroupName);
-
-      Assert.That(users.Any(), "No users were found for this group");
-    }
-
-    [Test]
-    public void it_returns_all_roles_by_user_group_name()
-    {
-      string userGroupName = "ALL_USERS_GROUP";
-      List<Role> roles = m_client.Users.AllUserRolesByUserGroup(userGroupName);
-
-      Assert.That(roles.Any(), "No roles were found for that userGroup");
-    }
-
-    [Test]
-    public void it_returns_all_users()
-    {
-      List<User> users = m_client.Users.All();
-
-      Assert.That(users.Any(), "No users found for this server");
-    }
-
-    [Test]
-    public void it_returns_all_user_roles_by_user_name()
-    {
-      string userName = "teamcitysharpuser";
-      List<Role> roles = m_client.Users.AllRolesByUserName(userName);
-
-      Assert.That(roles.Any(), "No roles found for this user");
-    }
-
-    [Test]
-    public void it_returns_all_user_groups_by_user_group_name()
-    {
-      string userName = m_username;
-      List<Group> groups = m_client.Users.AllGroupsByUserName(userName);
-
-      Assert.That(groups.Any(), "This user is not a member of any groups");
-    }
-
-    [Test]
-    public void it_returns_user_details_by_user()
-    {
-      string userName = m_username;
-      User details = m_client.Users.Details(userName);
-
-      Assert.That(details.Email.ToLowerInvariant().Contains("@"), "Incorrect email address");
-    }
-
-    [Test]
-    public void it_should_throw_exception_when_forbidden_status_code_returned()
-    {
-      var client = new TeamCityClient(m_server,m_useSsl);
-      client.ConnectAsGuest();
-
-      Assert.Throws<EasyHttp.Infrastructure.HttpException>(() => client.Users.All());
-
-    }
-  }
 }

--- a/src/Tests/IntegrationTests/SampleVcsUsage.cs
+++ b/src/Tests/IntegrationTests/SampleVcsUsage.cs
@@ -4,115 +4,146 @@ using NUnit.Framework;
 using System.Collections.Generic;
 using System.Configuration;
 using System.Linq;
+using EasyHttp.Infrastructure;
 using TeamCitySharp.DomainEntities;
 using TeamCitySharp.Fields;
 
 namespace TeamCitySharp.IntegrationTests
 {
-  [TestFixture]
-  public class when_interacting_to_get_vcs_details
-  {
-    private ITeamCityClient m_client;
-    private readonly string m_server;
-    private readonly bool m_useSsl;
-    private readonly string m_username;
-    private readonly string m_password;
-    private readonly string m_goodProjectId;
-
-    public when_interacting_to_get_vcs_details()
+    [TestFixture]
+    public class when_interacting_to_get_vcs_details
     {
-      m_server = ConfigurationManager.AppSettings["Server"];
-      bool.TryParse(ConfigurationManager.AppSettings["UseSsl"], out m_useSsl);
-      m_username = ConfigurationManager.AppSettings["Username"];
-      m_password = ConfigurationManager.AppSettings["Password"];
-      m_goodProjectId = ConfigurationManager.AppSettings["GoodProjectId"];
+        private ITeamCityClient m_client;
+        private readonly string m_server;
+        private readonly bool m_useSsl;
+        private readonly string m_username;
+        private readonly string m_password;
+        private readonly string m_goodProjectId;
 
+        public when_interacting_to_get_vcs_details()
+        {
+            m_server = ConfigurationManager.AppSettings["Server"];
+            bool.TryParse(ConfigurationManager.AppSettings["UseSsl"], out m_useSsl);
+            m_username = ConfigurationManager.AppSettings["Username"];
+            m_password = ConfigurationManager.AppSettings["Password"];
+            m_goodProjectId = ConfigurationManager.AppSettings["GoodProjectId"];
+        }
+
+        [SetUp]
+        public void SetUp()
+        {
+            m_client = new TeamCityClient(m_server, m_useSsl);
+            m_client.Connect(m_username, m_password);
+        }
+
+        [Test]
+        public void it_returns_exception_when_no_host_specified()
+        {
+            Assert.Throws<ArgumentNullException>(() => new TeamCityClient(null));
+        }
+
+        [Test]
+        public void it_returns_exception_when_host_does_not_exist()
+        {
+            var client = new TeamCityClient("test:81");
+            client.Connect("admin", "qwerty");
+
+            Assert.Throws<WebException>(() => client.VcsRoots.All());
+        }
+
+        [Test]
+        public void it_returns_exception_when_no_connection_formed()
+        {
+            var client = new TeamCityClient(m_server, m_useSsl);
+            Assert.Throws<ArgumentException>(() => client.VcsRoots.All());
+        }
+
+        [Test]
+        public void it_returns_all_vcs_roots()
+        {
+            List<VcsRoot> vcsRoots = m_client.VcsRoots.All();
+
+            Assert.That(vcsRoots.Any(), "No VCS Roots were found for the installation");
+        }
+
+        [TestCase("TestDrive_ReactApp_HttpsGithubComHypnosphiTeamcityReactDemoRefsHeadsMaster")]
+        public void it_returns_vcs_details_when_passing_vcs_root_id(string vcsRootId)
+        {
+            VcsRoot rootDetails = m_client.VcsRoots.ById(vcsRootId);
+
+            Assert.That(rootDetails != null, "Cannot find the specific VCSRoot");
+        }
+
+        [Test]
+        public void it_returns_correct_next_builds_with_filter()
+        {
+            var client = new TeamCityClient(m_server, m_useSsl);
+            client.ConnectAsGuest();
+
+            VcsRootField vcsRootField = VcsRootField.WithFields(id: true, href: true, lastChecked: true, name: true,
+                status: true, vcsName: true, version: true);
+            VcsRootsField vcsRootsField = VcsRootsField.WithFields(vcsRootField);
+            var vcsRoots = client.VcsRoots.GetFields(vcsRootsField.ToString()).All();
+
+            Assert.That(vcsRoots != null);
+        }
+
+        [Test, Ignore("Test user doesn't have the rights to create new VcsRoot on tested instance.")]
+        public void it_create_new_vsc()
+        {
+            var project = m_client.Projects.ById(m_goodProjectId);
+
+            VcsRoot vcsroot = new VcsRoot();
+            vcsroot.Id = project.Id + "_vcsroot1_01";
+            vcsroot.Name = project.Name + "_vcsroot1";
+            vcsroot.VcsName = "jetbrains.git";
+            vcsroot.Project = new Project();
+            vcsroot.Project.Id = project.Id;
+
+            Properties properties = new Properties();
+
+            properties.Add("agentCleanFilesPolicy", "IGNORED_ONLY");
+            vcsroot.Properties = properties;
+
+            var vcsroot2 = m_client.VcsRoots.CreateVcsRoot(vcsroot, project.Id);
+
+            m_client.VcsRoots.SetVcsRootValue(vcsroot2, VcsRootValue.Name, "TestChangeName");
+
+            m_client.VcsRoots.SetConfigurationProperties(vcsroot2, "agentCleanFilesPolicy", "ALL_UNTRACKED");
+            m_client.VcsRoots.SetConfigurationProperties(vcsroot2, "tt", "tt2");
+            m_client.VcsRoots.DeleteProperties(vcsroot2, "tt");
+            m_client.VcsRoots.DeleteVcsRoot(vcsroot2);
+        }
+
+        [Test]
+        public void it_throws_exception_create_new_vsc_forbidden()
+        {
+            var project = m_client.Projects.ById(m_goodProjectId);
+
+            VcsRoot vcsroot = new VcsRoot();
+            vcsroot.Id = project.Id + "_vcsroot1_01";
+            vcsroot.Name = project.Name + "_vcsroot1";
+            vcsroot.VcsName = "jetbrains.git";
+            vcsroot.Project = new Project();
+            vcsroot.Project.Id = project.Id;
+
+            Properties properties = new Properties();
+
+            properties.Add("agentCleanFilesPolicy", "IGNORED_ONLY");
+            vcsroot.Properties = properties;
+
+            try
+            {
+                m_client.VcsRoots.CreateVcsRoot(vcsroot, project.Id);
+            }
+            catch (HttpException e)
+            {
+                Assert.That(e.StatusCode == HttpStatusCode.Forbidden);
+            }
+            catch (Exception e)
+            {
+                Assert.Fail("CreateNewVsc faced an unexpected exception", e);
+            }
+        }
     }
-    [SetUp]
-    public void SetUp()
-    {
-      m_client = new TeamCityClient(m_server, m_useSsl);
-      m_client.Connect(m_username, m_password);
-    }
-
-    [Test]
-    public void it_returns_exception_when_no_host_specified()
-    {
-      Assert.Throws<ArgumentNullException>(() => new TeamCityClient(null));
-    }
-
-    [Test]
-    public void it_returns_exception_when_host_does_not_exist()
-    {
-      var client = new TeamCityClient("test:81");
-      client.Connect("admin", "qwerty");
-
-      Assert.Throws<WebException>(() => client.VcsRoots.All());
-    }
-
-    [Test]
-    public void it_returns_exception_when_no_connection_formed()
-    {
-      var client = new TeamCityClient(m_server, m_useSsl);
-      Assert.Throws<ArgumentException>(() => client.VcsRoots.All());
-    }
-
-    [Test]
-    public void it_returns_all_vcs_roots()
-    {
-      List<VcsRoot> vcsRoots = m_client.VcsRoots.All();
-
-      Assert.That(vcsRoots.Any(), "No VCS Roots were found for the installation");
-    }
-
-    [TestCase("TestDrive_ReactApp_HttpsGithubComHypnosphiTeamcityReactDemoRefsHeadsMaster")]
-    public void it_returns_vcs_details_when_passing_vcs_root_id(string vcsRootId)
-    {
-      VcsRoot rootDetails = m_client.VcsRoots.ById(vcsRootId);
-
-      Assert.That(rootDetails != null, "Cannot find the specific VCSRoot");
-    }
-
-    [Test]
-    public void it_returns_correct_next_builds_with_filter()
-    {
-      
-      var client = new TeamCityClient(m_server, m_useSsl);
-      client.ConnectAsGuest();
-
-      VcsRootField vcsRootField = VcsRootField.WithFields(id: true, href: true, lastChecked: true, name:true, status:true, vcsName: true, version:true );
-      VcsRootsField vcsRootsField = VcsRootsField.WithFields(vcsRootField);
-      var vcsRoots = client.VcsRoots.GetFields(vcsRootsField.ToString()).All();
-
-      Assert.That(vcsRoots != null);
-    }
-
-    [Test]
-    public void it_create_new_vsc()
-    {
-      var project = m_client.Projects.ById(m_goodProjectId);
-
-      VcsRoot vcsroot = new VcsRoot();
-      vcsroot.Id = project.Id + "_vcsroot1_01";
-      vcsroot.Name = project.Name + "_vcsroot1";
-      vcsroot.VcsName = "jetbrains.git";
-      vcsroot.Project = new Project();
-      vcsroot.Project.Id = project.Id;
-
-      Properties properties = new Properties();
-
-      properties.Add("agentCleanFilesPolicy", "IGNORED_ONLY");
-      vcsroot.Properties = properties;
-
-      var vcsroot2 = m_client.VcsRoots.CreateVcsRoot(vcsroot, project.Id);
-     
-      m_client.VcsRoots.SetVcsRootValue(vcsroot2, VcsRootValue.Name, "TestChangeName");
-
-      m_client.VcsRoots.SetConfigurationProperties(vcsroot2, "agentCleanFilesPolicy", "ALL_UNTRACKED");
-      m_client.VcsRoots.SetConfigurationProperties(vcsroot2, "tt", "tt2");
-      m_client.VcsRoots.DeleteProperties(vcsroot2,"tt");
-      m_client.VcsRoots.DeleteVcsRoot(vcsroot2);
-
-    }
-  }
 }


### PR DESCRIPTION
- Ignored a bunch of tests
- Added the check of no exceptions raised for calls that need an id that make sense for the test to succeed.  
It seems like a good compromise to detect breaking changes from the TeamCity server implementation without relying on too much runtime information.
- Checked that operations needing higher privileges that the testing user has are raising forbidden exceptions.

I have setup an Appveyor integration, let me know if you'd like me to create a pull request to add it to the your site (it adds a nice little test badge as you can see [here](https://github.com/chaami/TeamCitySharp/tree/ci))

With this commit integrated, the badge becomes green :wink: 