### PR TITLE
Fix AttachVcsRoot which throws exception from EasyHttp

### DIFF
--- a/src/TeamCitySharp/ActionTypes/VcsRoots.cs
+++ b/src/TeamCitySharp/ActionTypes/VcsRoots.cs
@@ -49,8 +49,12 @@ namespace TeamCitySharp.ActionTypes
 
     public VcsRoot AttachVcsRoot(BuildTypeLocator locator, VcsRoot vcsRoot)
     {
-      var xml = $@"<vcs-root-entry><vcs-root id=""{vcsRoot.Id}""/></vcs-root-entry>";
-      return m_caller.PostFormat<VcsRoot>(xml, HttpContentTypes.ApplicationXml, string.Empty,
+      var writer =
+        new JsonWriter(
+          new DataWriterSettings(new JsonResolverStrategy()));
+      var data = writer.Write(new VcsRootEntry{ VcsRoot = new VcsRoot { Id = vcsRoot.Id}});
+
+      return m_caller.PostFormat<VcsRoot>(data, HttpContentTypes.ApplicationJson, HttpContentTypes.ApplicationJson,
                                          "/app/rest/buildTypes/{0}/vcs-root-entries", locator);
     }
 
@@ -85,7 +89,7 @@ namespace TeamCitySharp.ActionTypes
       return m_caller.PostFormat<VcsRoot>(data, HttpContentTypes.ApplicationJson,
           HttpContentTypes.ApplicationJson, "/app/rest/vcs-roots",
           projectId);
-     
+
     }
     public void DeleteVcsRoot(VcsRoot vcsRoot)
     {


### PR DESCRIPTION
An unexpected error has occurred: The encoding requested does not have a corresponding decoder

Stacktrace:    at EasyHttp.Codecs.DefaultDecoder.ObtainDeserializer(String contentType) in C:\BuildAgent\work\f8da234c6955617\src\EasyHttp\Codecs\DefaultDecoder.cs:line 44
   at EasyHttp.Codecs.DefaultDecoder.DecodeToStatic[T](String input, String contentType) in C:\BuildAgent\work\f8da234c6955617\src\EasyHttp\Codecs\DefaultDecoder.cs:line 20
   at EasyHttp.Http.HttpResponse.StaticBody[T](String overrideContentType) in C:\BuildAgent\work\f8da234c6955617\src\EasyHttp\Http\HttpResponse.cs:line 115
   at TeamCitySharp.Connection.TeamCityCaller.Post[T](Object data, String contenttype, String urlPart, String accept)
   at TeamCitySharp.Connection.TeamCityCaller.PostFormat[T](Object data, String contenttype, String accept, String urlPart, Object[] parts)
   at TeamCitySharp.ActionTypes.VcsRoots.AttachVcsRoot(BuildTypeLocator locator, VcsRoot vcsRoot)