### PR TITLE
Fix '+' sign in URL

### DIFF
--- a/src/TeamCitySharp/Connection/TeamCityCaller.cs
+++ b/src/TeamCitySharp/Connection/TeamCityCaller.cs
@@ -243,8 +243,8 @@ namespace TeamCitySharp.Connection
     {
       var protocol = m_configuration.UseSSL ? "https://" : "http://";
       var authType = m_configuration.ActAsGuest ? "/guestAuth" : "/httpAuth";
-
-      return $"{protocol}{m_configuration.HostName}{authType}{urlPart}";
+      var uri = $"{protocol}{m_configuration.HostName}{authType}{urlPart}";
+      return Uri.EscapeUriString(uri).Replace("+", "%2B");
     }
 
     private HttpClient CreateHttpClient(string userName, string password, string accept)


### PR DESCRIPTION
**Situation:**
In a TeamCity build there's a artifact file containing a plus (+) character in it's filename.
The correct URL is:
http://HOSTNAME:PORT/repository/download/BUILD_NAME/2705720:id/FOLDER/Plus%2BPlus.txt

**Current result**
TeamCitySharp is downloading from the URL http://HOSTNAME:PORT/repository/download/BUILD_NAME/2705720:id/FOLDER/Plus+Plus.txt
The downloaded file contains a 404 error html page.