### PR TITLE
[TeamcitySharp] - Added support for new templates api endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,11 @@ Each area has its own list of methods available
     void DeleteAllBuildTypeParameters(BuildTypeLocator locator);
     void PutAllBuildTypeParameters(BuildTypeLocator locator, IDictionary<string, string> parameters);
 
+    /// <since>2017.2</since>
+    Templates GetTemplates(BuildTypeLocator locator); 
+    void AttachTemplates(BuildTypeLocator locator, Templates templateList);
+    void DetachTemplates(BuildTypeLocator locator);
+
 ### BuildInvestigation
 
     List<Investigation> All();

--- a/src/TeamCitySharp/ActionTypes/BuildConfigs.cs
+++ b/src/TeamCitySharp/ActionTypes/BuildConfigs.cs
@@ -453,15 +453,38 @@ namespace TeamCitySharp.ActionTypes
       }
     }
 
+    public Templates GetTemplates(BuildTypeLocator locator)
+    {
+      try
+      {
+        var templatedWrapper =
+          m_caller.GetFormat<Templates>(ActionHelper.CreateFieldUrl("/buildTypes/{0}/templates", m_fields), locator);
+        return templatedWrapper;
+      }
+      catch
+      {
+        return null;
+      }
+    }
+
     public void AttachTemplate(BuildTypeLocator locator, string templateId)
     {
       m_caller.PutFormat(templateId, HttpContentTypes.TextPlain, "/buildTypes/{0}/template", locator);
     }
 
+    public void AttachTemplates(BuildTypeLocator locator, Templates templateList)
+    {
+      m_caller.PutFormat<Templates>(templateList, HttpContentTypes.ApplicationJson, HttpContentTypes.ApplicationJson, "/buildTypes/{0}/templates", locator);
+    }
 
     public void DetachTemplate(BuildTypeLocator locator)
     {
       m_caller.DeleteFormat("/buildTypes/{0}/template", locator);
+    }
+
+    public void DetachTemplates(BuildTypeLocator locator)
+    {
+      m_caller.DeleteFormat("/buildTypes/{0}/templates", locator);
     }
 
     #region Custom structure for copy

--- a/src/TeamCitySharp/ActionTypes/IBuildConfigs.cs
+++ b/src/TeamCitySharp/ActionTypes/IBuildConfigs.cs
@@ -44,12 +44,12 @@ namespace TeamCitySharp.ActionTypes
     void DeleteBuildTrigger(BuildTypeLocator locator, string buildTriggerId);
 
     /// <summary>
+    /// DEPRECATED: After 2017.2 Please use AttachTemplates
     /// Makes a build type inherit a template.
     /// </summary>
     /// <param name="locatorBuildType">Locator for the build type which is to be associated with a template.</param>
     /// <param name="locatorTemplate">Locator for the template.</param>
     void SetBuildTypeTemplate(BuildTypeLocator locatorBuildType, BuildTypeLocator locatorTemplate);
-
 
     /// <summary>
     /// <para>Locates a build type by its locator.</para>
@@ -82,8 +82,25 @@ namespace TeamCitySharp.ActionTypes
     //Template
     Template CopyTemplate(string templateId, string templateName, string destinationProjectId, string newTemplateId = "");
     Template GetTemplate(BuildTypeLocator locator);
+    /// <summary>
+    /// Supports version 2017.2 and higher
+    /// </summary>
+    /// <param name="locator"></param>
+    /// <returns></returns>
+    Templates GetTemplates(BuildTypeLocator locator);
     void AttachTemplate(BuildTypeLocator locator, string templateId);
+    /// <summary>
+    /// Supports version 2017.2 and higher
+    /// </summary>
+    /// <param name="locator"></param>
+    /// <param name="templateList"></param>
+    void AttachTemplates(BuildTypeLocator locator, Templates templateList);
     void DetachTemplate(BuildTypeLocator locator);
+    /// <summary>
+    /// Supports version 2017.2 and higher
+    /// </summary>
+    /// <param name="locator"></param>
+    void DetachTemplates(BuildTypeLocator locator);
 
     // Dependencies
     ArtifactDependencies GetArtifactDependencies(string buildTypeId);

--- a/src/TeamCitySharp/Connection/ITeamCityCaller.cs
+++ b/src/TeamCitySharp/Connection/ITeamCityCaller.cs
@@ -15,6 +15,8 @@ namespace TeamCitySharp.Connection
 
     void PostFormat(object data, string contenttype, string urlPart, params object[] parts);
 
+    T PutFormat<T>(object data, string contenttype, string accept, string urlPart, params object[] parts);
+
     void PutFormat(object data, string contenttype, string urlPart, params object[] parts);
 
     void DeleteFormat(string urlPart, params object[] parts);
@@ -28,6 +30,8 @@ namespace TeamCitySharp.Connection
     void Get(string urlPart);
 
     T Post<T>(object data, string contenttype, string urlPart, string accept);
+
+    T Put<T>(object data, string contenttype, string urlPart, string accept);
 
     bool Authenticate(string urlPart, bool throwExceptionOnHttpError = true);
 

--- a/src/TeamCitySharp/Connection/TeamCityCaller.cs
+++ b/src/TeamCitySharp/Connection/TeamCityCaller.cs
@@ -66,6 +66,11 @@ namespace TeamCitySharp.Connection
       Post(data, contentType, string.Format(urlPart, parts), string.Empty);
     }
 
+    public T PutFormat<T>(object data, string contentType, string accept, string urlPart, params object[] parts)
+    {
+      return Put<T>(data, contentType, string.Format(urlPart, parts), accept);
+    }
+
     public void PutFormat(object data, string contentType, string urlPart, params object[] parts)
     {
       Put(data, contentType, string.Format(urlPart, parts), string.Empty);
@@ -152,6 +157,11 @@ namespace TeamCitySharp.Connection
     public T Post<T>(object data, string contentType, string urlPart, string accept)
     {
       return Post(data, contentType, urlPart, accept).StaticBody<T>();
+    }
+
+    public T Put<T>(object data, string contentType, string urlPart, string accept)
+    {
+      return Put(data, contentType, urlPart, accept).StaticBody<T>();
     }
 
     public bool Authenticate(string urlPart, bool throwExceptionOnHttpError = true)

--- a/src/TeamCitySharp/DomainEntities/BuildConfig.cs
+++ b/src/TeamCitySharp/DomainEntities/BuildConfig.cs
@@ -57,6 +57,9 @@ namespace TeamCitySharp.DomainEntities
     [JsonProperty("template")]
     public Template Template { get; set; }
 
+    [JsonProperty("templates")]
+    public Templates Templates { get; set; }
+
     [JsonProperty("parameters")]
     public Parameters Parameters { get; set; }
 

--- a/src/Tests/IntegrationTests/App.config
+++ b/src/Tests/IntegrationTests/App.config
@@ -7,6 +7,7 @@
     <add key="Password" value="password"/>
     <add key="GoodBuildConfigId" value="YouTrackSharp_ContinuousIntegration"/>
     <add key="GoodProjectId" value="YouTrackSharp"/>
+    <add key="GoodTemplateId" value="YouTrackSharpTemplate"/>
     <add key="GoodNumber" value=""/>
     <add key="QueuedBuildConfigId" value="bt864"/>
     <add key="QueuedProjectId" value="R2rml4net"/>  

--- a/src/Tests/IntegrationTests/SampleBuildsConfigsUsage.cs
+++ b/src/Tests/IntegrationTests/SampleBuildsConfigsUsage.cs
@@ -27,7 +27,7 @@ namespace TeamCitySharp.IntegrationTests
     private readonly string m_password;
     private readonly string m_goodBuildConfigId;
     private readonly string m_goodProjectId;
-
+    private readonly string m_goodTemplateId;
 
     public when_interations_to_get_build_configuration_details()
     {
@@ -37,6 +37,7 @@ namespace TeamCitySharp.IntegrationTests
       m_password = ConfigurationManager.AppSettings["Password"];
       m_goodBuildConfigId = ConfigurationManager.AppSettings["GoodBuildConfigId"];
       m_goodProjectId = ConfigurationManager.AppSettings["GoodProjectId"];
+      m_goodTemplateId = ConfigurationManager.AppSettings["GoodTemplateId"];
     }
 
     [SetUp]
@@ -473,6 +474,63 @@ namespace TeamCitySharp.IntegrationTests
       Assert.IsNotNull(buildConfig.Investigations.Href, "No Investigations href 3");
       Assert.IsNotNull(buildConfig.CompatibleAgents, "No CompatibleAgents 3");
       Assert.IsNotNull(buildConfig.CompatibleAgents.Href, "No CompatibleAgents href 3");
+    }
+
+    [Test]
+    public void it_returns_build_config_templates()
+    {
+      string buildConfigId = m_goodBuildConfigId;
+      var buildLocator = BuildTypeLocator.WithId(buildConfigId);
+      var templates = m_client.BuildConfigs.GetTemplates(buildLocator);
+      Assert.IsNotNull(templates, "No templates found, invalid templates call.");
+    }
+
+    [Test]
+    public void it_attaches_templates_to_build_config()
+    {
+      string buildConfigId = m_goodBuildConfigId;
+      var buildLocator = BuildTypeLocator.WithId(buildConfigId);
+      var buildConfig = new Template { Id = m_goodTemplateId };
+      var buildConfigList = new List<Template>() { buildConfig };
+      var templates = new Templates { BuildType = buildConfigList };
+      m_client.BuildConfigs.AttachTemplates(buildLocator, templates);
+
+      var templatesReceived = m_client.BuildConfigs.GetTemplates(buildLocator);
+      Assert.That(templatesReceived.BuildType.Any(), "Templates not attached");
+    }
+
+    [Test]
+    public void it_detaches_templates_from_build_config()
+    {
+      string buildConfigId = m_goodBuildConfigId;
+      var buildLocator = BuildTypeLocator.WithId(buildConfigId);
+      var buildConfig = new Template { Id = m_goodTemplateId };
+      var buildConfigList = new List<Template>() { buildConfig };
+      var templates = new Templates { BuildType = buildConfigList };
+      m_client.BuildConfigs.AttachTemplates(buildLocator, templates);
+      var templatesReceived = m_client.BuildConfigs.GetTemplates(buildLocator);
+      Assert.That(templatesReceived.BuildType.Any(), "Templates not attached");
+      m_client.BuildConfigs.DetachTemplates(buildLocator);
+
+      templatesReceived = m_client.BuildConfigs.GetTemplates(buildLocator);
+      Assert.That(!templatesReceived.BuildType.Any(), "Templates not detached");
+
+    }
+
+    [Test]
+    public void it_returns_build_config_templates_property()
+    {
+      string buildConfigId = m_goodBuildConfigId;
+      var buildLocator = BuildTypeLocator.WithId(buildConfigId);
+      var buildConfig = new Template { Id = m_goodTemplateId };
+      var buildConfigList = new List<Template>() { buildConfig };
+      var templates = new Templates { BuildType = buildConfigList };
+      m_client.BuildConfigs.AttachTemplates(buildLocator, templates);
+      var templatesReceived = m_client.BuildConfigs.GetTemplates(buildLocator);
+      Assert.That(templatesReceived.BuildType.Any(), "Templates not attached");
+
+      var templatesField = m_client.BuildConfigs.ByConfigurationId(buildConfigId).Templates;
+      Assert.IsNotNull(templatesField, "Templates property not retrieved correctly");
     }
 
     #region private


### PR DESCRIPTION
DESCRIPTION:
Support for templates api endpoint (Version >= TeamCity 2017.2)
Old endpoint ended in /template
New endpoint ends in /templates

TEST:

REVIEWER:

REFERENCES:
-TP Task: None
-Defect: None
-Wiki: None