### PR TITLE
[TeamcitySharp] - Add method to create a build configuration with other properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Each area has its own list of methods available
     List<BuildConfig> ByProjectId(string projectId);
     List<BuildConfig> ByProjectName(string projectName);
     bool ModifTrigger(string format, string oldTriggerConfigurationId, string id);
+    BuildConfig CreateConfiguration(BuildConfig buildConfig);
     BuildConfig CreateConfiguration(string projectName, string configurationName);
     BuildConfig CreateConfigurationByProjectId(string projectId, string configurationName);
     BuildConfig Copy(string buildConfigId, string buildConfigName, string destinationProjectId, string newBuildTypeId = "");

--- a/src/TeamCitySharp/ActionTypes/BuildConfigs.cs
+++ b/src/TeamCitySharp/ActionTypes/BuildConfigs.cs
@@ -110,6 +110,12 @@ namespace TeamCitySharp.ActionTypes
       return buildWrapper?.BuildType ?? new List<BuildConfig>();
     }
 
+    public BuildConfig CreateConfiguration(BuildConfig buildConfig)
+    {
+      return m_caller.PostFormat<BuildConfig>(buildConfig, HttpContentTypes.ApplicationJson,
+        HttpContentTypes.ApplicationJson, "/buildTypes");
+    }
+
     public BuildConfig CreateConfiguration(string projectName, string configurationName)
     {
       return m_caller.PostFormat<BuildConfig>(configurationName, HttpContentTypes.TextPlain,

--- a/src/TeamCitySharp/ActionTypes/IBuildConfigs.cs
+++ b/src/TeamCitySharp/ActionTypes/IBuildConfigs.cs
@@ -19,6 +19,7 @@ namespace TeamCitySharp.ActionTypes
     List<BuildConfig> ByProjectId(string projectId);
     List<BuildConfig> ByProjectName(string projectName);
     bool ModifTrigger(string buildTypeId, string triggerId, string newBt);
+    BuildConfig CreateConfiguration(BuildConfig buildConfig);
     BuildConfig CreateConfiguration(string projectName, string configurationName);
     BuildConfig CreateConfigurationByProjectId(string projectId, string configurationName);
 

--- a/src/Tests/IntegrationTests/SampleBuildsConfigsUsage.cs
+++ b/src/Tests/IntegrationTests/SampleBuildsConfigsUsage.cs
@@ -545,6 +545,31 @@ namespace TeamCitySharp.IntegrationTests
       Assert.IsTrue(new FileInfo(destination).Length > 0);
     }
 
+    [Test]
+    public void it_creates_build_configuration()
+    {
+      var currentBuildId = "testId";
+      var buildProject = new Project() { Id = m_goodProjectId };
+      var parameters = new Parameters
+        { Property = new List<Property>() { new Property() { Name = "category", Value = "test"} } };
+      var buildConfig = new BuildConfig() { Id = currentBuildId, Name = "testNewConfig", Project = buildProject, Parameters = parameters };
+
+      try
+      {
+        buildConfig = m_client.BuildConfigs.CreateConfiguration(buildConfig);
+
+        Assert.That(buildConfig.Id == currentBuildId);
+      }
+      catch (Exception e)
+      {
+        Assert.Fail($"{e.Message}", e);
+      }
+      finally
+      {
+        m_client.BuildConfigs.DeleteConfiguration(BuildTypeLocator.WithId(currentBuildId));
+      }
+    }
+
     #region private
     private string GetXml(object data)
     {


### PR DESCRIPTION
DESCRIPTION:
Build configuration can now be created with all properties instead of adding them after creation.